### PR TITLE
Fix for BUG-2289 Missing documentation for Customer Properties Dictionary

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -124,7 +124,8 @@ All API's are a translation of the API's available to native platforms and follo
 ### Dictionaries
 
 #### Customer Properties Dictionary
-The Customer Properties is passed a IDictionary in this release future release will support an interface to allow for code completion and refactoring.
+The Customer Properties is passed an IDictionary.
+In a future release Localytics Xamarin SDK will support an interface to allow for code completion and refactoring.
 
 | Dictionary Key Name    | Value Description  |
 |------------------------|-------|

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -121,6 +121,21 @@ All API's are a translation of the API's available to native platforms and follo
 | SetLocationMonitoringEnabled | Enable or disable location monitoring for geofence monitoring | 
 | PushTokenInfo | return a string version of Push Token on all platforms.| 
 
+### Dictionaries
+
+#### Customer Properties Dictionary
+The Customer Properties is passed a IDictionary in this release future release will support an interface to allow for code completion and refactoring.
+
+| Dictionary Key Name    | Value Description  |
+|------------------------|-------|
+| customerId | Customer Id |
+| firstName  | First Name of the customer |
+| lastName   | Last Name of the customer  |
+| fullName   | Full Name of the customer  |
+| emailAddress | Email Address of the customer |
+
+This Dictionary is to be passed to TagCustomerLoggedIn and TagCustomerRegistered API.
+
 ### Events
 
 Events are available as static events in the LocalyticsSDK class in the Localytics.Shared namespace.


### PR DESCRIPTION
Focus on the Family reported that it's not possible to pass the Customer Object but the dictionary that is common to both platforms is not documented.

This is an attempt to fix the Docs. the Plan is to make it a ICustomer interface in a future release.