### PR TITLE
Fix two properties declared as native methods in LLInboxViewController

### DIFF
--- a/LocalyticsXamarin/LocalyticsXamarin.iOS/ApiDefinition.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.iOS/ApiDefinition.cs
@@ -312,11 +312,11 @@ namespace LocalyticsXamarin.IOS
 		UIView CreativeLoadErrorView { get; set; }
 
         // @property(nonatomic, assign) BOOL enableSwipeDelete;
-        [Export("enableSwipeDelete:", ArgumentSemantic.Assign)]
+        [Export("enableSwipeDelete", ArgumentSemantic.Assign)]
         bool EnableSwipeDelete { get; set; }
 
         // @property(nonatomic, assign) BOOL enableDetailViewDelete;
-        [Export("enableDetailViewDelete:", ArgumentSemantic.Assign)]
+        [Export("enableDetailViewDelete", ArgumentSemantic.Assign)]
         bool EnableDetailViewDelete { get; set; }
 
         // -(LLInboxCampaign * _Nullable)campaignForRowAtIndexPath:(NSIndexPath * _Nonnull)indexPath;


### PR DESCRIPTION
There are two properties in LLInboxViewController class having errors in export attribute. It declares method instead of properties. This could cause build failure in a Xamarin.Forms application built in release configuration.