### PR TITLE
Plugin Name was incorrectly captioned. Also, the plugin version number was not committed to git

### DIFF
--- a/LocalyticsXamarin/LocalyticsXamarin.Android/Properties/AssemblyInfo.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using Android.App;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("0.0.0.*")]
+[assembly: AssemblyVersion ("5.2.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/LocalyticsXamarin/LocalyticsXamarin.Common/Properties/AssemblyInfo.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.Common/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("40.0.0.*")]
+[assembly: AssemblyVersion("5.2.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/LocalyticsXamarin/LocalyticsXamarin.Shared/LocalyticsSDK.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.Shared/LocalyticsSDK.cs
@@ -264,7 +264,7 @@ namespace LocalyticsXamarin.Shared
         internal static void UpdatePluginVersion()
         {
             var ver = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-            string versionString = string.Format("XAMARIN_{0}.{1}.{2}", ver.Major, ver.Minor, ver.Build);
+            string versionString = string.Format("Xamarin_{0}.{1}.{2}", ver.Major, ver.Minor, ver.Build);
             Console.WriteLine("Version is {0}", versionString);
 #if __IOS__
     Localytics.SetOptions(Foundation.NSDictionary.FromObjectAndKey(new Foundation.NSString(versionString), new Foundation.NSString("plugin_library")));

--- a/LocalyticsXamarin/LocalyticsXamarin.iOS/Properties/AssemblyInfo.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.iOS/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using Foundation;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("0.0.0.*")]
+[assembly: AssemblyVersion ("5.2.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Xamarin plugin version was incorrectly reported as XAMARIN
Also, the plugin version number for 5.2.0 was not committed to git. Fix this so anyone pulling from source would build the correct version.