### PR TITLE
5.4.1 fixes

### DIFF
--- a/LocalyticsXamarin/LocalyticsSample/LocalyticsSample.cs
+++ b/LocalyticsXamarin/LocalyticsSample/LocalyticsSample.cs
@@ -89,7 +89,7 @@ namespace LocalyticsSample.Shared
             localytics.TagSearched("query", "type", 5, new Dictionary<string, string>());
             localytics.TagShared("name", "id", "type", "method", new Dictionary<string, string>());
             localytics.TagContentRated("name", "id", "type", 1, new Dictionary<string, string>());
-            LocalyticsXamarin.Shared.Customer customer = new LocalyticsXamarin.Shared.Customer("!234", "John", "Appleseed", "John Appleseed", "jappleseed@localytics.com");
+            Customer customer = new Customer("!234", "John", "Appleseed", "John Appleseed", "jappleseed@localytics.com");
 
             localytics.TagCustomerRegistered(customer, "method", new Dictionary<string, string>());
 

--- a/LocalyticsXamarin/LocalyticsXamarin.Common/Customer.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.Common/Customer.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using LocalyticsXamarin.Common;
-using LocalyticsXamarin.Shared;
 
-namespace LocalyticsXamarin.Shared
+namespace LocalyticsXamarin.Common
 {
     public class Customer : LocalyticsXamarin.Common.IXLCustomer
     {

--- a/LocalyticsXamarin/LocalyticsXamarin.NuGet/Localytics.NuGet.nuproj
+++ b/LocalyticsXamarin/LocalyticsXamarin.NuGet/Localytics.NuGet.nuproj
@@ -56,51 +56,6 @@
     <Content Include="..\LocalyticsXamarin.Shared\LocalyticsXamarinForms.cs">
       <Link>LocalyticsXamarinForms.cs</Link>
     </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLCampaignBase.h">
-      <Link>Localytics.framework\Headers\LLCampaignBase.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLCustomer.h">
-      <Link>Localytics.framework\Headers\LLCustomer.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLGeofence.h">
-      <Link>Localytics.framework\Headers\LLGeofence.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLInAppCampaign.h">
-      <Link>Localytics.framework\Headers\LLInAppCampaign.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLInAppConfiguration.h">
-      <Link>Localytics.framework\Headers\LLInAppConfiguration.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLInboxCampaign.h">
-      <Link>Localytics.framework\Headers\LLInboxCampaign.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLInboxDetailViewController.h">
-      <Link>Localytics.framework\Headers\LLInboxDetailViewController.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLInboxViewController.h">
-      <Link>Localytics.framework\Headers\LLInboxViewController.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLPlacesCampaign.h">
-      <Link>Localytics.framework\Headers\LLPlacesCampaign.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLRegion.h">
-      <Link>Localytics.framework\Headers\LLRegion.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LLWebViewCampaign.h">
-      <Link>Localytics.framework\Headers\LLWebViewCampaign.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\Localytics-Framework.h">
-      <Link>Localytics.framework\Headers\Localytics-Framework.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\Localytics.h">
-      <Link>Localytics.framework\Headers\Localytics.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\Headers\LocalyticsTypes.h">
-      <Link>Localytics.framework\Headers\LocalyticsTypes.h</Link>
-    </Content>
-    <Content Include="..\..\Localytics-iOS-Latest\Localytics.framework\PrivateHeaders\LLPushToInboxCampaignJson.h">
-      <Link>Localytics.framework\PrivateHeaders\LLPushToInboxCampaignJson.h</Link>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageFile Include="..\..\Localytics-iOS-Latest\Localytics.framework\Modules\module.modulemap">

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ ifneq ($(VER),)
 	@cd LocalyticsXamarin/iOS && msbuild /t:Rebuild /p:Configuration=Release 
 #Build NUget Package
 	@cd LocalyticsXamarin/LocalyticsXamarin.NuGet && msbuild /t:Rebuild /p:Configuration=Release 
-	@echo Publish LocalyticsXamarin/LocalyticsXamarin.NuGet/bin/Release/Localytics.$(VER).nupkg 
+	@echo Publish LocalyticsXamarin/LocalyticsXamarin.NuGet/bin/Release/LocalyticsXamarin.$(VER).nupkg 
 endif


### PR DESCRIPTION
Fix name of the package in Makefile
Fix name of the XML documentation to match module name
Remove Objective c headers from nuget package
Fix name space of module in common to prevent conflict with shared code.