### PR TITLE
MessagingListenerAdapter instead of Listener; Fix Session Start InApp…

### DIFF
--- a/LocalyticsXamarin/LocalyticsMessagingSample.Android/LocalyticsAutoIntegrateApplication.cs
+++ b/LocalyticsXamarin/LocalyticsMessagingSample.Android/LocalyticsAutoIntegrateApplication.cs
@@ -32,42 +32,75 @@ namespace LocalyticsMessagingSample.Android
             Localytics.AutoIntegrate(this);
             Localytics.SetLocationMonitoringEnabled(true);
 
-			//// Analytics callbacks
+			// Analytics callbacks
             LocalyticsSDK.LocalyticsDidTagEvent += LL_OnLocalyticsDidTagEvent;
             LocalyticsSDK.LocalyticsSessionWillOpen += LL_OnLocalyticsSessionWillOpen;
             LocalyticsSDK.LocalyticsSessionDidOpen += LL_OnLocalyticsSessionDidOpen;
             LocalyticsSDK.LocalyticsSessionWillClose += LL_OnLocalyticsSessionWillClose;
 
-            //// Messaging callbacks
+            // Messaging callbacks
+            LocalyticsSDK.InAppDelaySessionStartMessagesDelegate = LocalyticsSDK_InAppDelaySessionStartMessagesDelegate; ;
+            LocalyticsSDK.InAppShouldShowDelegate = LocalyticsSDK_InAppShouldShowDelegate;
+
             LocalyticsSDK.InAppDidDismissEvent += LL_OnLocalyticsDidDismissInAppMessage;
-            LocalyticsSDK.InAppDidDisplayEvent += LL_OnLocalyticsDidDisplayInAppMessage;
             LocalyticsSDK.InAppWillDismissEvent += LL_OnLocalyticsWillDismissInAppMessage;
-            LocalyticsSDK.InAppWillDisplayDelegate += LL_OnLocalyticsWillDisplayInAppMessage;
+            LocalyticsSDK.InAppDidDisplayEvent += LL_OnLocalyticsDidDisplayInAppMessage;
+            LocalyticsSDK.InAppWillDisplayDelegate = LL_OnLocalyticsWillDisplayInAppMessage;
+
+
+            LocalyticsSDK.PlacesShouldDisplayCampaignDelegate = LL_OnLocalyticsShouldShowPlacesPushNotification;
+            Localytics.WillShowPlacesPushNotification += LL_OnLocalyticsWillShowPlacesPushNotification;
 
             Localytics.ShouldShowPushNotification += LL_OnLocalyticsShouldShowPushNotification;
-            LocalyticsSDK.PlacesShouldDisplayCampaignDelegate += LL_OnLocalyticsShouldShowPlacesPushNotification;
-
             Localytics.WillShowPushNotification += LL_OnLocalyticsWillShowPushNotification;
-            Localytics.WillShowPlacesPushNotification += LL_OnLocalyticsWillShowPlacesPushNotification;
 
             //// Location callbacks
             LocalyticsSDK.LocalyticsDidUpdateLocation += LL_OnLocalyticsDidUpdateLocation;
-            LocalyticsSDK.LocalyticsDidTriggerRegions += (sender, e) => {
-                Console.WriteLine("XamarinEvent LocalyticsDidTriggerRegions " + e);
-            };
+            LocalyticsSDK.LocalyticsDidTriggerRegions += LocalyticsSDK_LocalyticsDidTriggerRegions;
             LocalyticsSDK.LocalyticsDidUpdateMonitoredGeofences += LL_OnLocalyticsDidUpdateMonitoredGeofences;
         
-            Localytics.ShouldPromptForLocationPermission += (arg) => {
-                Console.WriteLine("XamarinEvent ShouldPromptForLocationPermission " + arg);
-                return true;
-            };
+            Localytics.ShouldPromptForLocationPermission += Localytics_ShouldPromptForLocationPermission;
 
-            Localytics.DeeplinkToSettings += (i, c) =>
-            {
-                Console.WriteLine("XamarinEvent ShouldPromptForLocationPermission " + i + c);
-                return true;
-            };
+            LocalyticsSDK.ShouldDeepLinkDelegate += LocalyticsSDK_ShouldDeepLinkDelegate;
 
+            Localytics.DeeplinkToSettings += Localytics_DeeplinkToSettings;
+
+            LocalyticsSDK.SharedInstance.OpenSession();
+        }
+
+        void LocalyticsSDK_LocalyticsDidTriggerRegions(object sender, LocalyticsDidTriggerRegionsEventArgs e)
+        {
+            Console.WriteLine("XamarinCallback: LocalyticsDidTriggerRegions " + e);
+        }
+
+        bool Localytics_ShouldPromptForLocationPermission(Campaign arg)
+        {
+            Console.WriteLine("XamarinCallback: ShouldPromptForLocationPermission " + arg);
+            return true;
+        }
+
+        bool LocalyticsSDK_ShouldDeepLinkDelegate(string deepLink)
+        {
+            Console.WriteLine("XamarinCallback: Request to deeplink to url {0}", deepLink);
+            return true;
+        }
+
+        bool Localytics_DeeplinkToSettings(object intent, Campaign campaign)
+        {
+            Console.WriteLine("XamarinCallback: ShouldPromptForLocationPermission {0} campaign = {1}", intent , campaign);
+            return true;
+        }
+
+        bool LocalyticsSDK_InAppShouldShowDelegate(InAppCampaign arg)
+        {
+            Console.WriteLine("XamarinCallback: Should Show InApp {0}", arg);
+            return true;
+        }
+
+        bool LocalyticsSDK_InAppDelaySessionStartMessagesDelegate()
+        {
+            Console.WriteLine("XamarinCallback: Delay InApp Session Start. Not Delayed");
+            return false;
         }
 
         void LL_OnLocalyticsDidTagEvent(object sender, LocalyticsDidTagEventEventArgs eventArgs)
@@ -77,87 +110,87 @@ namespace LocalyticsMessagingSample.Android
             double? customerValueIncrease = eventArgs.CustomerValue;
             if (attributes != null)
             {
-                Console.WriteLine("Did tag event: name: " + eventName + " attributes.Count: " + attributes.Count + " customerValueIncrease: " + customerValueIncrease);
+                Console.WriteLine("XamarinCallback: Did tag event: name: " + eventName + " attributes.Count: " + attributes.Count + " customerValueIncrease: " + customerValueIncrease);
             }
             else
             {
-                Console.WriteLine("Did tag event: name: " + eventName + " attributes.Count: " + 0 + " customerValueIncrease: " + customerValueIncrease);
+                Console.WriteLine("XamarinCallback: Did tag event: name: " + eventName + " attributes.Count: " + 0 + " customerValueIncrease: " + customerValueIncrease);
             }
         }
 
         void LL_OnLocalyticsSessionWillClose(object sender, EventArgs eventArgs)
         {
-            Console.WriteLine("Session will close");
+            Console.WriteLine("XamarinCallback: Session will close");
         }
 
         void LL_OnLocalyticsSessionDidOpen(object sender, LocalyticsSessionDidOpenEventArgs args)
         {
-            Console.WriteLine("Session did open: isFirst: " + args.First + " isUpgrade: " + args.Upgrade + " isResume: " + args.Resume);
+            Console.WriteLine("XamarinCallback: Session did open: isFirst: " + args.First + " isUpgrade: " + args.Upgrade + " isResume: " + args.Resume);
         }
 
         void LL_OnLocalyticsSessionWillOpen(object sender, LocalyticsSessionWillOpenEventArgs args)
         {
-            Console.WriteLine("Session will open: isFirst: " + args.First + " isUpgrade: " + args.Upgrade + " isResume: " + args.Resume);
+            Console.WriteLine("XamarinCallback: Session will open: isFirst: " + args.First + " isUpgrade: " + args.Upgrade + " isResume: " + args.Resume);
         }
 
         void LL_OnLocalyticsDidDismissInAppMessage(object sender, InAppDidDismissEventArgs eventArgs)
         {
-            Console.WriteLine("DidDismissInAppMessage");
+            Console.WriteLine("XamarinCallback: DidDismissInAppMessage");
         }
 
         void LL_OnLocalyticsDidDisplayInAppMessage(object sender, InAppDidDisplayEventArgs eventArgs)
         {
-            Console.WriteLine("DidDisplayInAppMessage");
+            Console.WriteLine("XamarinCallback: DidDisplayInAppMessage");
         }
 
         void LL_OnLocalyticsWillDismissInAppMessage(object sender, InAppWillDismissEventArgs eventArgs)
         {
-            Console.WriteLine("WillDismissInAppMessage");
+            Console.WriteLine("XamarinCallback: WillDismissInAppMessage");
         }
 
         InAppConfiguration LL_OnLocalyticsWillDisplayInAppMessage(InAppCampaign campaign, InAppConfiguration configuration)
         {
-            Console.WriteLine("WillDisplayInAppMessage");
+            Console.WriteLine("XamarinCallback: WillDisplayInAppMessage");
             return configuration;
         }
 
         bool LL_OnLocalyticsShouldShowPushNotification(PushCampaign campaign)
         {
-            Console.WriteLine("Should show push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
+            Console.WriteLine("XamarinCallback: Should show push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
             return true;
         }
 
         NotificationCompat.Builder LL_OnLocalyticsWillShowPushNotification(NotificationCompat.Builder builder, PushCampaign campaign)
         {
-            Console.WriteLine("Will show push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
+            Console.WriteLine("XamarinCallback: Will show push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
             return builder;
         }
 
         bool LL_OnLocalyticsShouldShowPlacesPushNotification(PlacesCampaign campaign)
         {
-            Console.WriteLine("Should show places notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
+            Console.WriteLine("XamarinCallback: Should show places notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
             return true;
         }
 
         NotificationCompat.Builder LL_OnLocalyticsWillShowPlacesPushNotification(NotificationCompat.Builder builder, PlacesCampaign campaign)
         {
-            Console.WriteLine("Will show places push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
+            Console.WriteLine("XamarinCallback: Will show places push notification. Name: " + campaign.Name + ". Campaign Id: " + campaign.CampaignId + ". Message: " + campaign.Message);
             return builder;
         }
 
         void LL_OnLocalyticsDidUpdateLocation(object sender, LocalyticsDidUpdateLocationEventArgs eventArgs)
         {
-            Console.WriteLine("Did update location: " + eventArgs.Location);
+            Console.WriteLine("XamarinCallback: Did update location: " + eventArgs.Location);
         }
 
         void LL_OnLocalyticsDidTriggerRegions(object sender, LocalyticsDidTriggerRegionsEventArgs eventArgs)
         {
-            Console.WriteLine("Did trigger regions: " + eventArgs.Regions + " with event: " + eventArgs.RegionEvent);
+            Console.WriteLine("XamarinCallback: Did trigger regions: " + eventArgs.Regions + " with event: " + eventArgs.RegionEvent);
         }
 
         void LL_OnLocalyticsDidUpdateMonitoredGeofences(object sender, LocalyticsDidUpdateMonitoredGeofencesEventArgs eventArgs)
         {
-            Console.WriteLine("Did update monitored geofences. Added: " + eventArgs.AddedRegions + " and removed: " + eventArgs.RemovedRegions);
+            Console.WriteLine("XamarinCallback: Did update monitored geofences. Added: " + eventArgs.AddedRegions + " and removed: " + eventArgs.RemovedRegions);
         }
     }
 }

--- a/LocalyticsXamarin/LocalyticsMessagingSample.Android/MainActivity.cs
+++ b/LocalyticsXamarin/LocalyticsMessagingSample.Android/MainActivity.cs
@@ -88,6 +88,19 @@ namespace LocalyticsMessagingSample.Android
                     }
                 }
             };
+
+            Button testModeButton = FindViewById<Button>(Resource.Id.testMode);
+            testModeButton.Click += (object sender, EventArgs e) =>
+            {
+                LocalyticsXamarin.Shared.LocalyticsSDK.SharedInstance.TestModeEnabled = true;
+            };
+
+            Button customEventButton = FindViewById<Button>(Resource.Id.tagEventWithNameButton);
+            customEventButton.Click += (object sender, EventArgs e) =>
+            {
+                TextView textView = FindViewById<TextView>(Resource.Id.eventNameTV);
+                LocalyticsXamarin.Shared.LocalyticsSDK.SharedInstance.TagEvent(textView.Text);
+            };
         }
 
         protected override void OnResume()

--- a/LocalyticsXamarin/LocalyticsMessagingSample.Android/Properties/AndroidManifest.xml
+++ b/LocalyticsXamarin/LocalyticsMessagingSample.Android/Properties/AndroidManifest.xml
@@ -9,7 +9,7 @@
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 	<uses-permission android:name="com.localytics.xamarin.messaging.sample.permission.C2D_MESSAGE" />
 	<permission android:name="com.localytics.xamarin.messaging.sample.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-	<application android:label="LocalyticsMessagingSample.Android">
+	<application android:label="LocalyticsMessagingSample.Android" android:theme="@android:style/Theme.Material.Light">
 		<meta-data android:name="LOCALYTICS_APP_KEY" android:value="YOUR-LOCALYTICS-APP-KEY" />
 		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
 		<activity android:name="com.localytics.android.PushTrackingActivity" />

--- a/LocalyticsXamarin/LocalyticsMessagingSample.Android/Resources/layout/Main.axml
+++ b/LocalyticsXamarin/LocalyticsMessagingSample.Android/Resources/layout/Main.axml
@@ -28,4 +28,43 @@
         android:text="Start Places"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
+    <Button
+        android:id="@+id/testMode"
+        android:text="Test Mode"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    
+    <LinearLayout
+        android:orientation="horizontal"
+        android:minWidth="25px"
+        android:minHeight="25px"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+        
+        <TextView android:id="@+id/eventNameLabel" android:minHeight="25px"
+                  android:minWidth="90px"
+                  android:enabled="false"
+                  android:text="Event Name:" 
+                  android:layout_width="0dp"
+                   android:layout_height="wrap_content"
+                  android:layout_weight=".25"
+                  />
+        <EditText
+            android:minHeight="25px"
+            android:minWidth="240px"
+            android:enabled="true"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="inappcfgnone"
+            android:id="@+id/eventNameTV"
+        android:layout_weight=".75"/>
+        </LinearLayout>
+        
+        <Button
+        android:id="@+id/tagEventWithNameButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="TagEvent With Event Name" />
+    
+
 </LinearLayout>

--- a/LocalyticsXamarin/LocalyticsXamarin.Android/Additions/Localytics.cs
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/Additions/Localytics.cs
@@ -27,7 +27,7 @@ namespace LocalyticsXamarin.Android
 		static Localytics()
 		{
 			LocalyticsSDK.UpdatePluginVersion();
-			Localytics.SetMessagingListener(new IMessagingListenerV2Implementor());
+			Localytics.SetMessagingListener(new MessagingListenerImplementation());
             Localytics.SetCallToActionListener(new CTAListenerImplementation());
 		}
 
@@ -46,40 +46,31 @@ namespace LocalyticsXamarin.Android
         public static Func<NotificationCompat.Builder, NativePlacesCampaign, NotificationCompat.Builder> WillShowPlacesPushNotification;
         public static Func<NotificationCompat.Builder, NativePushCampaign, NotificationCompat.Builder> WillShowPushNotification;
 
-        [global::Android.Runtime.Register("mono/com/localytics/android/MessagingListenerV2Implementor")]
-        internal sealed partial class IMessagingListenerV2Implementor : global::Java.Lang.Object, IMessagingListenerV2
-        {
-            public IMessagingListenerV2Implementor()
-                : base(
-                    global::Android.Runtime.JNIEnv.StartCreateInstance("mono/com/localytics/android/MessagingListenerV2Implementor", "()V"),
-                    JniHandleOwnership.TransferLocalRef)
-            {
-                global::Android.Runtime.JNIEnv.FinishCreateInstance(((global::Java.Lang.Object)this).Handle, "()V");
-                //this.sender = sender;
-            }
 
-            public void LocalyticsDidDisplayInAppMessage()
+        internal sealed class MessagingListenerImplementation : MessagingListenerV2Adapter
+        {
+            public override void LocalyticsDidDisplayInAppMessage()
             {
                 var __h = LocalyticsSDK.InAppDidDisplayEvent;
                 if (__h != null)
                     __h(null, new InAppDidDisplayEventArgs());
             }
 
-            public void LocalyticsWillDismissInAppMessage()
+            public override void LocalyticsWillDismissInAppMessage()
             {
                 var __h = LocalyticsSDK.InAppWillDismissEvent;
                 if (__h != null)
                     __h(null, new InAppWillDismissEventArgs());
             }
 
-            public void LocalyticsDidDismissInAppMessage()
+            public override void LocalyticsDidDismissInAppMessage()
             {
                 var __h = LocalyticsSDK.InAppDidDismissEvent;
                 if (__h != null)
                     __h(null, new InAppDidDismissEventArgs());
             }
 
-            public bool LocalyticsShouldDeeplink(string p0)
+            public override bool LocalyticsShouldDeeplink(string p0)
             {
                 var __h = LocalyticsSDK.ShouldDeepLinkDelegate;
                 if (__h != null)
@@ -87,15 +78,16 @@ namespace LocalyticsXamarin.Android
                 return true;
             }
 
-            public bool LocalyticsShouldDelaySessionStartInAppMessages()
+            public override bool LocalyticsShouldDelaySessionStartInAppMessages()
             {
                 var __h = LocalyticsSDK.InAppDelaySessionStartMessagesDelegate;
+                // By Default we should not delay. i.e., when no delegate is defined.
                 if (__h != null)
                     return __h();
-                return true;
+                return false; // Dont Delay Session start.
             }
 
-            public bool LocalyticsShouldShowInAppMessage(global::LocalyticsXamarin.Android.InAppCampaign p0)
+            public override bool LocalyticsShouldShowInAppMessage(global::LocalyticsXamarin.Android.InAppCampaign p0)
             {
                 var __h = LocalyticsSDK.InAppShouldShowDelegate;
                 if (__h != null)
@@ -103,7 +95,7 @@ namespace LocalyticsXamarin.Android
                 return true;
             }
 
-            public bool LocalyticsShouldShowPlacesPushNotification(global::LocalyticsXamarin.Android.PlacesCampaign p0)
+            public override bool LocalyticsShouldShowPlacesPushNotification(Android.PlacesCampaign p0)
             {
                 var __h = LocalyticsSDK.PlacesShouldDisplayCampaignDelegate;
                 if (__h != null)
@@ -111,7 +103,7 @@ namespace LocalyticsXamarin.Android
                 return true;
             }
 
-            public bool LocalyticsShouldShowPushNotification(global::LocalyticsXamarin.Android.PushCampaign p0)
+            public override bool LocalyticsShouldShowPushNotification(global::LocalyticsXamarin.Android.PushCampaign p0)
             {
                 var __h = ShouldShowPushNotification;
                 if (__h != null)
@@ -119,7 +111,7 @@ namespace LocalyticsXamarin.Android
                 return true;
             }
 
-            public global::LocalyticsXamarin.Android.InAppConfiguration LocalyticsWillDisplayInAppMessage(global::LocalyticsXamarin.Android.InAppCampaign p0, global::LocalyticsXamarin.Android.InAppConfiguration p1)
+            public override global::LocalyticsXamarin.Android.InAppConfiguration LocalyticsWillDisplayInAppMessage(global::LocalyticsXamarin.Android.InAppCampaign p0, global::LocalyticsXamarin.Android.InAppConfiguration p1)
             {
                 var __h = LocalyticsSDK.InAppWillDisplayDelegate;
                 if (__h != null)
@@ -127,29 +119,19 @@ namespace LocalyticsXamarin.Android
                 return p1;
             }
 
-            public global::Android.Support.V4.App.NotificationCompat.Builder LocalyticsWillShowPlacesPushNotification(global::Android.Support.V4.App.NotificationCompat.Builder p0, global::LocalyticsXamarin.Android.PlacesCampaign p1)
+            public override global::Android.Support.V4.App.NotificationCompat.Builder LocalyticsWillShowPlacesPushNotification(global::Android.Support.V4.App.NotificationCompat.Builder p0, global::LocalyticsXamarin.Android.PlacesCampaign p1)
             {
                 var __h = WillShowPlacesPushNotification;
                 if (__h != null)
                     return __h(p0, p1);
                 return p0;
             }
-            public global::Android.Support.V4.App.NotificationCompat.Builder LocalyticsWillShowPushNotification(global::Android.Support.V4.App.NotificationCompat.Builder p0, global::LocalyticsXamarin.Android.PushCampaign p1)
+            public override NotificationCompat.Builder LocalyticsWillShowPushNotification(NotificationCompat.Builder p0, Android.PushCampaign p1)
             {
                 var __h = WillShowPushNotification;
                 if (__h != null)
                     return __h(p0, p1);
                 return p0;
-            }
-
-            internal static bool __IsEmpty(IMessagingListenerV2Implementor value)
-            {
-                return LocalyticsSDK.InAppDidDisplayEvent != null && LocalyticsSDK.InAppWillDismissEvent != null &&
-                                    LocalyticsSDK.InAppDidDismissEvent != null && LocalyticsSDK.ShouldDeepLinkDelegate != null &&
-                                    LocalyticsSDK.InAppDelaySessionStartMessagesDelegate != null && LocalyticsSDK.InAppShouldShowDelegate != null &&
-                                    LocalyticsSDK.PlacesShouldDisplayCampaignDelegate != null && ShouldShowPushNotification != null &&
-                                    LocalyticsSDK.InAppWillDisplayDelegate != null && WillShowPlacesPushNotification != null &&
-                    WillShowPushNotification != null;
             }
         }
 

--- a/LocalyticsXamarin/LocalyticsXamarin.Android/Transforms/Metadata.xml
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/Transforms/Metadata.xml
@@ -238,7 +238,6 @@
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'MarketingProvider')]" />
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'MarketingWebView')]" />
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'MessagingListenerBroker')]" />
-<remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'MessagingListenerV2Adapter')]" />
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'MigrationDatabaseHelper')]" />
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'NotificationAction')]" />
 <remove-node path="/api/package[@name='com.localytics.android']/class[contains(@name,'PlacesManager')]" />


### PR DESCRIPTION
Changes
1. Use the Adapter instead of the MessagingListener
2. Fix the Issue which prevents Session Start Inapp to display when implementing some other delegate.
3. Fix the Sample Code so that the Inbox list text displays properly.

Testing 
   Ran InApp in test mode, From tagEvent and Session start and validated appropriate callbacks are invoked.
