### PR TITLE
Removed dependency on Google Play Services Ads from library project

### DIFF
--- a/LocalyticsXamarin/LocalyticsXamarin.Android/LocalyticsXamarin.Android.csproj
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/LocalyticsXamarin.Android.csproj
@@ -83,17 +83,6 @@
       <HintPath>..\packages\Xamarin.GooglePlayServices.Location.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Location.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Ads.Lite">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Ads.Lite.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Ads.Lite.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Gass">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Gass.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Gass.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Ads">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Ads.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Ads.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Xamarin.AndroidX.Activity, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.AndroidX.Activity.1.2.0.1\lib\monoandroid90\Xamarin.AndroidX.Activity.dll</HintPath>
     </Reference>
@@ -253,7 +242,6 @@
   <Import Project="..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets')" />
   <Import Project="..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets')" />
   <Import Project="..\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Gass.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Gass.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Gass.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Gass.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Activity.1.2.0.1\build\monoandroid9.0\Xamarin.AndroidX.Activity.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Activity.1.2.0.1\build\monoandroid9.0\Xamarin.AndroidX.Activity.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Annotation.1.1.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Annotation.1.1.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Annotation.Experimental.1.0.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.Experimental.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Annotation.Experimental.1.0.0.9\build\monoandroid9.0\Xamarin.AndroidX.Annotation.Experimental.targets')" />

--- a/LocalyticsXamarin/LocalyticsXamarin.Android/packages.config
+++ b/LocalyticsXamarin/LocalyticsXamarin.Android/packages.config
@@ -60,13 +60,9 @@
   <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="2.2.5" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.Google.Dagger" version="2.27.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Ads.Base" version="119.7.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Ads.Identifier" version="117.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Ads.Lite" version="119.7.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.Base" version="117.6.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.CloudMessaging" version="116.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
-  <package id="Xamarin.GooglePlayServices.Gass" version="119.7.0" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.Measurement.Base" version="118.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.Measurement.Sdk.Api" version="118.0.2" targetFramework="monoandroid11.0" requireReinstallation="true" />
   <package id="Xamarin.GooglePlayServices.Stats" version="117.0.0" targetFramework="monoandroid11.0" requireReinstallation="true" />


### PR DESCRIPTION
Fixes #59

Version 6.0.4 of the Xamarin Android nuget package requires a Google AdMob app ID configured and a run time exception is thrown if it is not configured. This is not required when using the native Android Localytics library. To reproduce run the latest sample android app.

The PR removes the Ad Mob packages from the library project so they aren't required dependencies. If the consumer of the library needs this functionality they can add these, as is shown by the sample app.